### PR TITLE
fix(index): resolve Windows framework paths from AIWG_ROOT

### DIFF
--- a/src/artifacts/query-engine.ts
+++ b/src/artifacts/query-engine.ts
@@ -1071,8 +1071,9 @@ export interface ShowMetadataParams extends ShowParams {}
 
 function resolveMetadataPath(cwd: string, aiwgRoot: string | null, entry: MetadataEntry): string {
   if (path.isAbsolute(entry.path)) return entry.path;
-  if (aiwgRoot && entry.path.startsWith('agentic/code/')) {
-    return path.join(aiwgRoot, entry.path);
+  const normalizedEntryPath = entry.path.replace(/\\/g, '/');
+  if (aiwgRoot && normalizedEntryPath.startsWith('agentic/code/')) {
+    return path.join(aiwgRoot, normalizedEntryPath);
   }
   if ((entry as ProvenancedEntry).indexScope === 'user' && entry.path.startsWith('~/.aiwg/')) {
     return path.join(process.env.HOME ?? '', entry.path.slice(2));

--- a/test/unit/artifacts/query-engine.test.ts
+++ b/test/unit/artifacts/query-engine.test.ts
@@ -239,6 +239,60 @@ describe('Artifact Query Engine', () => {
     }
   });
 
+  it('resolves Windows-style framework paths against AIWG_ROOT (#128)', async () => {
+    const corpusRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aiwg-corpus-'));
+    const indexedPath = 'agentic\\code\\frameworks\\knowledge-base\\skills\\kb-ingest\\SKILL.md';
+    const artifactPath = path.join(
+      corpusRoot,
+      'agentic',
+      'code',
+      'frameworks',
+      'knowledge-base',
+      'skills',
+      'kb-ingest',
+      'SKILL.md',
+    );
+    fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+    fs.writeFileSync(artifactPath, '# KB Ingest\n');
+
+    const projectIndexDir = path.join(tmpDir, INDEX_DIR, 'project');
+    fs.mkdirSync(projectIndexDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectIndexDir, 'metadata.json'),
+      JSON.stringify({
+        version: '1.0.0',
+        builtAt: '2026-07-12T00:00:00Z',
+        buildTimeMs: 1,
+        entries: {
+          [indexedPath]: createMockEntry({
+            path: indexedPath,
+            type: 'skill',
+            name: 'kb-ingest',
+            title: 'KB Ingest',
+          }),
+        },
+      }),
+    );
+
+    const prevRoot = process.env.AIWG_ROOT;
+    process.env.AIWG_ROOT = corpusRoot;
+    try {
+      await showArtifact(tmpDir, {
+        typeFilter: ['skill'],
+        name: 'kb-ingest',
+        graph: 'project',
+        json: true,
+      });
+      const parsed = JSON.parse(consoleSpy.mock.calls.map(c => c[0]).join(''));
+      expect(parsed.path).toBe(artifactPath);
+      expect(parsed.content).toContain('# KB Ingest');
+    } finally {
+      if (prevRoot === undefined) delete process.env.AIWG_ROOT;
+      else process.env.AIWG_ROOT = prevRoot;
+      fs.rmSync(corpusRoot, { recursive: true, force: true });
+    }
+  });
+
   it('resolves a persona agent via the corpus fallback when not in any index (#1623 U5)', async () => {
     // An index exists (so showArtifact does not early-exit) but does NOT
     // contain the persona agent — the exact "un-indexed / stale framework


### PR DESCRIPTION
## Summary

Normalize backslash-delimited framework index paths before `AIWG_ROOT` corpus detection so `aiwg show` reads packaged artifacts correctly when invoked from a Windows project directory.

## Linked issues

- Closes #128

## Changes

- Normalize separators used to classify framework corpus paths in `resolveMetadataPath`.
- Add a Windows-style index-path regression test for `showArtifact`.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] Specific suite: `npx vitest run --config config/vitest.config.js test/unit/artifacts/query-engine.test.ts` (13/13 passed)
- [ ] `npm test` passes: the full suite has pre-existing Windows path and timing failures outside this change.
- [ ] CI green on this branch / commit
- [x] Manual verification: the regression test confirms a backslash-delimited framework entry resolves to the artifact under `AIWG_ROOT`, not the project cwd.

`npm run build:cli` reaches TypeScript compilation, then the existing Windows-only `build:copy-mjs` script fails because its `^src/` replacement does not match `src\\...` paths. Linux CI remains the authoritative packaging check.

## Risk and rollback

- **Risk**: low - normalization is limited to framework corpus path classification; absolute, user-scoped, and project-local resolution behavior is unchanged.
- **Rollback**: revert commit `569d8258`.

## Policy reminders

- **Delivery mode**: `pr-required`; this change is delivered through an issue-linked feature branch and PR.
- **No AI attribution**: no attribution trailers or generated-with text included.
- **CI green before done**: upstream checks will be monitored before considering this complete.

## Documentation

- [ ] CHANGELOG updated (not required for this targeted bug fix)
- [ ] Release notes / announcement updated (not releasing)
- [ ] Affected agent/skill/rule docs updated (no contract change)