### PR TITLE
Sync Gitea release 2026.9.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "support@aiwg.io"
   },
   "description": "AIWG - Modular agentic framework for SDLC, marketing automation, and workflow orchestration. 200+ agents, 67+ CLI commands, 400+ deployable agent/skill/command/rule artifacts.",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "plugins": [
     {
       "name": "sdlc",
       "source": "./agentic/code/plugins/sdlc",
       "description": "Complete SDLC framework with 180+ specialized agents for software development lifecycle management.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -23,7 +23,7 @@
       "name": "marketing",
       "source": "./agentic/code/plugins/marketing",
       "description": "Marketing automation framework with 37 specialized agents for campaign management.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -35,7 +35,7 @@
       "name": "voice",
       "source": "./agentic/code/plugins/voice",
       "description": "Voice profile system for consistent, authentic writing.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -47,7 +47,7 @@
       "name": "writing",
       "source": "./agentic/code/plugins/writing",
       "description": "Writing quality validation and AI pattern detection.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -59,7 +59,7 @@
       "name": "utils",
       "source": "./agentic/code/plugins/utils",
       "description": "Core AIWG utilities for context regeneration and workspace management.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -71,7 +71,7 @@
       "name": "forensics",
       "source": "./agentic/code/plugins/forensics",
       "description": "Digital forensics and incident response framework with 14 specialized agents covering target profiling, evidence acquisition, log/memory/container/cloud analysis, IOC extraction, and reporting.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -83,7 +83,7 @@
       "name": "security-engineering",
       "source": "./agentic/code/plugins/security-engineering",
       "description": "Applied security framework for cryptographic primitive selection, chain-of-trust design, authentication factor analysis, supply-chain trust, and physical-threat modeling. Complements OWASP-style application audits.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -95,7 +95,7 @@
       "name": "research",
       "source": "./agentic/code/plugins/research",
       "description": "Research workflow framework with 9 specialized agents for discovery, acquisition, synthesis, citation management, GRADE quality assessment, and OAIS-compliant archival.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -107,7 +107,7 @@
       "name": "media-curator",
       "source": "./agentic/code/plugins/media-curator",
       "description": "Media archive management framework with 7 specialized agents for source discovery, acquisition (yt-dlp / Internet Archive / Bandcamp), quality assessment, metadata tagging, and provenance tracking.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -119,7 +119,7 @@
       "name": "ops",
       "source": "./agentic/code/plugins/ops",
       "description": "Operational infrastructure framework with 12 specialized agents covering incident response, runbook execution, fleet inventory, certificate lifecycle, and disaster recovery planning.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -131,7 +131,7 @@
       "name": "knowledge-base",
       "source": "./agentic/code/plugins/knowledge-base",
       "description": "Knowledge-base / wiki framework with skills for ingestion, query, and lint. Build a structured, citable corpus with cross-references and concept pages.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -143,7 +143,7 @@
       "name": "hooks",
       "source": "./agentic/code/plugins/hooks",
       "description": "Claude Code hooks for workflow tracing and observability.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -155,7 +155,7 @@
       "name": "validation-complete",
       "source": "./agentic/code/plugins/validation-complete",
       "description": "Validation Complete for AIWG",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -167,7 +167,7 @@
       "name": "agent-loop",
       "source": "./agentic/code/plugins/agent-loop",
       "description": "Iterative AI coding loops with automatic recovery - iteration beats perfection",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -189,7 +189,7 @@
       "name": "agent-persistence",
       "source": "./agentic/code/plugins/agent-persistence",
       "description": "Human-in-the-loop (HITL) gate definitions for agent operations. Provides reusable YAML gates for destructive-action authorization, false-positive override, and recovery escalation. Loaded by agent loops and orchestrators that need bounded human checkpoints.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -209,7 +209,7 @@
       "name": "agentic-installer",
       "source": "./agentic/code/plugins/agentic-installer",
       "description": "Structured YAML manifests for reproducible, agent-driven software installation across platforms. Scripts are the primary artifact; agentic instructions handle adaptation and recovery.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -228,7 +228,7 @@
       "name": "aiwg-evals",
       "source": "./agentic/code/plugins/aiwg-evals",
       "description": "Automated evaluation framework for agent quality, based on KAMI benchmark methodology and ReAct patterns",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -248,7 +248,7 @@
       "name": "aiwg-dev",
       "source": "./agentic/code/plugins/aiwg-dev",
       "description": "Developer tooling for building AIWG itself and AIWG addons/frameworks. Not for end users — install explicitly with `aiwg use aiwg-dev`.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -267,7 +267,7 @@
       "name": "auto-memory",
       "source": "./agentic/code/plugins/auto-memory",
       "description": "Automatic memory seed templates for AIWG projects",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -285,7 +285,7 @@
       "name": "browser-control",
       "source": "./agentic/code/plugins/browser-control",
       "description": "Drive a real, user-installed Chromium-derived browser from an AIWG agent. Wraps @playwright/mcp with a setup wizard, health-check doctor, allow-list enforcement, and an opinionated agent persona that respects authorization and audit boundaries.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -309,7 +309,7 @@
       "name": "color-palette",
       "source": "./agentic/code/plugins/color-palette",
       "description": "Color palette selection and review tooling with color theory fundamentals, current trend research, and accessibility analysis.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -329,7 +329,7 @@
       "name": "context-curator",
       "source": "./agentic/code/plugins/context-curator",
       "description": "Context curation and distractor filtering for production-grade agent reliability",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -341,7 +341,7 @@
       "name": "compound-memory",
       "source": "./agentic/code/plugins/compound-memory",
       "description": "Governed orchestration across AIWG line memory, semantic memory, and llm-wiki.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -360,7 +360,7 @@
       "name": "daemon",
       "source": "./agentic/code/plugins/daemon",
       "description": "Persistent daemon session capabilities: Concierge front-end, session memory, scheduler integration",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -380,7 +380,7 @@
       "name": "doc-intelligence",
       "source": "./agentic/code/plugins/doc-intelligence",
       "description": "Documentation intelligence addon for scraping, extraction, analysis, and generated-docs auditing.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -401,7 +401,7 @@
       "name": "droid-bridge",
       "source": "./agentic/code/plugins/droid-bridge",
       "description": "MCP server bridging Claude Code to Factory Droid for batch operations and automated fixes",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -419,7 +419,7 @@
       "name": "guided-implementation",
       "source": "./agentic/code/plugins/guided-implementation",
       "description": "Bounded iteration control for autonomous issue-to-code implementation",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -431,7 +431,7 @@
       "name": "line-memory",
       "source": "./agentic/code/plugins/line-memory",
       "description": "Bounded, plain-text project memory with least-recently-used retention.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -450,7 +450,7 @@
       "name": "llm-wiki",
       "source": "./agentic/code/plugins/llm-wiki",
       "description": "LLM-maintained markdown wiki that compounds as sources are ingested. Thin topology declaration on the semantic memory kernel — ships schema profiles and page templates, no custom mechanics.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -473,7 +473,7 @@
       "name": "nlp-prod",
       "source": "./agentic/code/plugins/nlp-prod",
       "description": "Tools, skills, and CLI extensions for designing and productionizing LLM inference pipelines. Pattern-guided, slim by default, eval-first.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -498,7 +498,7 @@
       "name": "prose-integration",
       "source": "./agentic/code/plugins/prose-integration",
       "description": "Tools for reading, parsing, validating, and executing OpenProse programs from AIWG workflows",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -518,7 +518,7 @@
       "name": "rlm",
       "source": "./agentic/code/plugins/rlm",
       "description": "RLM-inspired recursive context decomposition for processing arbitrarily large codebases and document corpora through programmatic sub-agent delegation",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -540,7 +540,7 @@
       "name": "semantic-memory",
       "source": "./agentic/code/plugins/semantic-memory",
       "description": "Topology-agnostic semantic memory operations: ingest, lint, query-capture, and structured event logging. Consumers declare a memory topology in their manifest.json; kernel skills read that contract to parameterize behavior.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -562,7 +562,7 @@
       "name": "skill-factory",
       "source": "./agentic/code/plugins/skill-factory",
       "description": "Build, enhance, validate, and package Claude skills end-to-end. Coordinates skill-builder, skill-enhancer, quality-checker, and skill-packager via the skill-architect agent.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -582,7 +582,7 @@
       "name": "star-prompt",
       "source": "./agentic/code/plugins/star-prompt",
       "description": "Tasteful prompt to encourage users to star the repository after successful command completion",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -600,7 +600,7 @@
       "name": "testing-quality",
       "source": "./agentic/code/plugins/testing-quality",
       "description": "Testing enforcement, quality metrics, and automation skills",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -612,7 +612,7 @@
       "name": "twelve-factor",
       "source": "./agentic/code/plugins/twelve-factor",
       "description": "Design-time and audit-time workflows for Twelve-Factor and modern 12+ Factor cloud-native application practices.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -635,7 +635,7 @@
       "name": "uat-mcp",
       "source": "./agentic/code/plugins/uat-mcp",
       "description": "Agent-executable acceptance testing via MCP connections — generate, execute, and report on UAT plans that validate MCP tool surfaces.",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },
@@ -655,7 +655,7 @@
       "name": "verbalized-sampling",
       "source": "./agentic/code/plugins/verbalized-sampling",
       "description": "Training-free prompting technique that improves output diversity by 1.6-2.1x through verbalized probability distributions, addressing RLHF mode collapse",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "author": {
         "name": "AIWG Contributors"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project uses [Calendar Versioning (CalVer)](https://calver.org/) with n
 
 ## [Unreleased]
 
+## [2026.9.3] - 2026-09-05 - "Broader provider support, reliable project discovery"
+
 ### Added
 
 - Experimental Google Antigravity CLI provider (`antigravity`, alias and
@@ -20,6 +22,11 @@ and this project uses [Calendar Versioning (CalVer)](https://calver.org/) with n
   extension bridge, model discovery, JSON/RPC execution, bounded teams, and
   title-prefixed session imports. See the [provider guide](docs/providers/omp.md)
   for the pinned version, support limits, and removal workflow (#2244–#2256).
+- Opt-in Fortemi live storage qualification now produces sanitized, durable
+  receipts binding the tested revision, endpoint identity, server contract,
+  complete operation inventory, mutation status, and resource bounds. Dataset
+  workflows also gain a schema-first live contract preflight and durable UAT
+  plan; these checks do not certify Server persistence or recovery.
 
 ### Changed
 
@@ -28,8 +35,37 @@ and this project uses [Calendar Versioning (CalVer)](https://calver.org/) with n
   published at [pi.dev](https://pi.dev/) across current provider documentation.
 - Synchronized OMP across the public homepage, provider and capability
   matrices, setup navigation, operator references, and getting-started guides.
-  The public platform list now matches the 13 named provider integrations and
-  no longer counts Ollama, an LLM backend, as an AIWG deployment provider.
+  Together with Antigravity, the public platform list now matches 14 named
+  provider integrations and no longer counts Ollama, an LLM backend, as an
+  AIWG deployment provider.
+
+### Fixed
+
+- Existing project-local skills remain discoverable when their Fortemi Core
+  project cache is missing, stale, or corrupt. Discovery falls back to the existing
+  local project index, and framework deployment, refresh, and upgrade synchronize
+  the project index after local bundle reconciliation (#2155).
+- Portable workflows, including `aiwg-guide`, documentation consolidation,
+  and semantic-memory skills, declare `platforms: [all]` across canonical and
+  plugin copies. Newly supported providers can deploy them without stale
+  provider allowlists silently excluding them (#2282).
+- Fortemi MCP reads accept nested original/revised content, and search results
+  with opaque note IDs retrieve missing path metadata before applying subsystem
+  filtering. Search hydration is bounded to 50 results.
+- Concurrent SQLite graph initialization now retries journal-mode and schema
+  contention within the configured busy timeout and closes failed connections.
+  Deterministic lock regressions and renewed source-bound benchmark evidence
+  cover the change.
+
+### Release boundaries
+
+- OMP remains experimental at its reviewed 18.1.10 baseline. Antigravity remains
+  experimental with offline conformance pinned to 1.1.26; authenticated model
+  execution has not been qualified.
+- Fortemi Server remains alpha and pre-certification. Live probes require an
+  explicitly configured endpoint, default to read-only, and gate writes
+  separately. Fortemi Core capability discovery is a separate static-cache
+  path and does not require a live Server endpoint.
 
 ## [2026.9.2] - 2026-09-04 - "Pi from resources to runtime"
 

--- a/agentic/code/addons/aiwg-utils/skills/aiwg-guide/SKILL.md
+++ b/agentic/code/addons/aiwg-utils/skills/aiwg-guide/SKILL.md
@@ -2,7 +2,7 @@
 namespace: aiwg
 name: aiwg-guide
 description: Contextual AIWG help — explains current version features, answers how-to questions, routes live queries to the steward
-platforms: [claude-code, codex, opencode, warp, cursor, windsurf, copilot, factory, openclaw, hermes]
+platforms: [all]
 
 ---
 

--- a/agentic/code/addons/aiwg-utils/skills/doc-consolidate/SKILL.md
+++ b/agentic/code/addons/aiwg-utils/skills/doc-consolidate/SKILL.md
@@ -7,7 +7,7 @@ commandHint:
   allowedTools: Read, Write, Bash, Glob, Grep
   category: utilities
   orchestration: true
-platforms: [claude-code]
+platforms: [all]
 
 ---
 

--- a/agentic/code/addons/semantic-memory/skills/memory-ingest/SKILL.md
+++ b/agentic/code/addons/semantic-memory/skills/memory-ingest/SKILL.md
@@ -3,7 +3,7 @@ name: memory-ingest
 description: Ingest a source into any consumer's semantic memory by reading the topology contract
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 triggers:
   - "help my AI remember what we decided"
   - "help me preserve project decisions between sessions"

--- a/agentic/code/addons/semantic-memory/skills/memory-lint/SKILL.md
+++ b/agentic/code/addons/semantic-memory/skills/memory-lint/SKILL.md
@@ -3,7 +3,7 @@ name: memory-lint
 description: Health-check any consumer's semantic memory by composing structural and domain-specific checks
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 ---
 
 # memory-lint

--- a/agentic/code/addons/semantic-memory/skills/memory-log-append/SKILL.md
+++ b/agentic/code/addons/semantic-memory/skills/memory-log-append/SKILL.md
@@ -3,7 +3,7 @@ name: memory-log-append
 description: Append a structured event to a consumer's semantic memory log
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 ---
 
 # memory-log-append

--- a/agentic/code/addons/semantic-memory/skills/memory-log-render/SKILL.md
+++ b/agentic/code/addons/semantic-memory/skills/memory-log-render/SKILL.md
@@ -3,7 +3,7 @@ name: memory-log-render
 description: Generate a human-readable Markdown view from a consumer's JSON Lines event log
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 ---
 
 # memory-log-render

--- a/agentic/code/addons/semantic-memory/skills/memory-query-capture/SKILL.md
+++ b/agentic/code/addons/semantic-memory/skills/memory-query-capture/SKILL.md
@@ -3,7 +3,7 @@ name: memory-query-capture
 description: Capture query synthesis as durable pages in semantic memory
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 ---
 
 # memory-query-capture

--- a/agentic/code/frameworks/sdlc-complete/skills/doc-consolidate/SKILL.md
+++ b/agentic/code/frameworks/sdlc-complete/skills/doc-consolidate/SKILL.md
@@ -7,7 +7,7 @@ commandHint:
   allowedTools: Read, Write, Bash, Glob, Grep
   category: utilities
   orchestration: true
-platforms: [claude-code]
+platforms: [all]
 
 ---
 

--- a/agentic/code/plugins/agent-loop/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/agent-loop/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-loop",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Iterative AI coding loops with automatic recovery - iteration beats perfection",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/agent-persistence/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/agent-persistence/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-persistence",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Human-in-the-loop (HITL) gate definitions for agent operations. Provides reusable YAML gates for destructive-action authorization, false-positive override, and recovery escalation. Loaded by agent loops and orchestrators that need bounded human checkpoints.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/agentic-installer/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/agentic-installer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-installer",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Structured YAML manifests for reproducible, agent-driven software installation across platforms. Scripts are the primary artifact; agentic instructions handle adaptation and recovery.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/aiwg-dev/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/aiwg-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aiwg-dev",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Developer tooling for building AIWG itself and AIWG addons/frameworks. Not for end users — install explicitly with `aiwg use aiwg-dev`.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/aiwg-evals/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/aiwg-evals/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aiwg-evals",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Automated evaluation framework for agent quality, based on KAMI benchmark methodology and ReAct patterns",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/auto-memory/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/auto-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-memory",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Automatic memory seed templates for AIWG projects",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/browser-control/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/browser-control/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-control",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Drive a real, user-installed Chromium-derived browser from an AIWG agent. Wraps @playwright/mcp with a setup wizard, health-check doctor, allow-list enforcement, and an opinionated agent persona that respects authorization and audit boundaries.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/codex-sdlc/skills/doc-consolidate/SKILL.md
+++ b/agentic/code/plugins/codex-sdlc/skills/doc-consolidate/SKILL.md
@@ -7,7 +7,7 @@ commandHint:
   allowedTools: Read, Write, Bash, Glob, Grep
   category: utilities
   orchestration: true
-platforms: [claude-code]
+platforms: [all]
 
 ---
 

--- a/agentic/code/plugins/color-palette/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/color-palette/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "color-palette",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Color palette selection and review tooling with color theory fundamentals, current trend research, and accessibility analysis.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/compound-memory/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/compound-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compound-memory",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Governed orchestration across AIWG line memory, semantic memory, and llm-wiki.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/context-curator/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/context-curator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-curator",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Context curation and distractor filtering for production-grade agent reliability",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/daemon/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/daemon/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "daemon",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Persistent daemon session capabilities: Concierge front-end, session memory, scheduler integration",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/doc-intelligence/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/doc-intelligence/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-intelligence",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Documentation intelligence addon for scraping, extraction, analysis, and generated-docs auditing.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/droid-bridge/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/droid-bridge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "droid-bridge",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "MCP server bridging Claude Code to Factory Droid for batch operations and automated fixes",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/forensics/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/forensics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forensics",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Digital forensics and incident response framework with 14 specialized agents covering target profiling, evidence acquisition, log/memory/container/cloud analysis, IOC extraction, and reporting.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/guided-implementation/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/guided-implementation/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guided-implementation",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Bounded iteration control for autonomous issue-to-code implementation",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/hooks/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Claude Code hooks for workflow tracing and observability.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/knowledge-base/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/knowledge-base/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-base",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Knowledge-base / wiki framework with skills for ingestion, query, and lint. Build a structured, citable corpus with cross-references and concept pages.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/line-memory/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/line-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "line-memory",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Bounded, plain-text project memory with least-recently-used retention.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/llm-wiki/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/llm-wiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "LLM-maintained markdown wiki that compounds as sources are ingested. Thin topology declaration on the semantic memory kernel — ships schema profiles and page templates, no custom mechanics.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/marketing/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/marketing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "marketing",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Marketing automation framework with 37 specialized agents for campaign management.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/media-curator/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/media-curator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "media-curator",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Media archive management framework with 7 specialized agents for source discovery, acquisition (yt-dlp / Internet Archive / Bandcamp), quality assessment, metadata tagging, and provenance tracking.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/nlp-prod/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/nlp-prod/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nlp-prod",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Tools, skills, and CLI extensions for designing and productionizing LLM inference pipelines. Pattern-guided, slim by default, eval-first.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/ops/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Operational infrastructure framework with 12 specialized agents covering incident response, runbook execution, fleet inventory, certificate lifecycle, and disaster recovery planning.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/prose-integration/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/prose-integration/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prose-integration",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Tools for reading, parsing, validating, and executing OpenProse programs from AIWG workflows",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/research/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/research/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "research",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Research workflow framework with 9 specialized agents for discovery, acquisition, synthesis, citation management, GRADE quality assessment, and OAIS-compliant archival.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/rlm/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/rlm/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rlm",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "RLM-inspired recursive context decomposition for processing arbitrarily large codebases and document corpora through programmatic sub-agent delegation",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/sdlc/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/sdlc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Complete SDLC framework with 180+ specialized agents for software development lifecycle management.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/sdlc/skills/doc-consolidate/SKILL.md
+++ b/agentic/code/plugins/sdlc/skills/doc-consolidate/SKILL.md
@@ -7,7 +7,7 @@ commandHint:
   allowedTools: Read, Write, Bash, Glob, Grep
   category: utilities
   orchestration: true
-platforms: [claude-code]
+platforms: [all]
 
 ---
 

--- a/agentic/code/plugins/security-engineering/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/security-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-engineering",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Applied security framework for cryptographic primitive selection, chain-of-trust design, authentication factor analysis, supply-chain trust, and physical-threat modeling. Complements OWASP-style application audits.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/semantic-memory/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/semantic-memory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-memory",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Topology-agnostic semantic memory operations: ingest, lint, query-capture, and structured event logging. Consumers declare a memory topology in their manifest.json; kernel skills read that contract to parameterize behavior.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/semantic-memory/skills/memory-ingest/SKILL.md
+++ b/agentic/code/plugins/semantic-memory/skills/memory-ingest/SKILL.md
@@ -3,7 +3,7 @@ name: memory-ingest
 description: Ingest a source into any consumer's semantic memory by reading the topology contract
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 triggers:
   - "help my AI remember what we decided"
   - "help me preserve project decisions between sessions"

--- a/agentic/code/plugins/semantic-memory/skills/memory-lint/SKILL.md
+++ b/agentic/code/plugins/semantic-memory/skills/memory-lint/SKILL.md
@@ -3,7 +3,7 @@ name: memory-lint
 description: Health-check any consumer's semantic memory by composing structural and domain-specific checks
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 ---
 
 # memory-lint

--- a/agentic/code/plugins/semantic-memory/skills/memory-log-append/SKILL.md
+++ b/agentic/code/plugins/semantic-memory/skills/memory-log-append/SKILL.md
@@ -3,7 +3,7 @@ name: memory-log-append
 description: Append a structured event to a consumer's semantic memory log
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 ---
 
 # memory-log-append

--- a/agentic/code/plugins/semantic-memory/skills/memory-log-render/SKILL.md
+++ b/agentic/code/plugins/semantic-memory/skills/memory-log-render/SKILL.md
@@ -3,7 +3,7 @@ name: memory-log-render
 description: Generate a human-readable Markdown view from a consumer's JSON Lines event log
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 ---
 
 # memory-log-render

--- a/agentic/code/plugins/semantic-memory/skills/memory-query-capture/SKILL.md
+++ b/agentic/code/plugins/semantic-memory/skills/memory-query-capture/SKILL.md
@@ -3,7 +3,7 @@ name: memory-query-capture
 description: Capture query synthesis as durable pages in semantic memory
 namespace: aiwg
 category: kernel
-platforms: [claude, copilot, cursor, factory, windsurf, warp, codex, opencode, openclaw, hermes]
+platforms: [all]
 ---
 
 # memory-query-capture

--- a/agentic/code/plugins/skill-factory/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/skill-factory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-factory",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Build, enhance, validate, and package Claude skills end-to-end. Coordinates skill-builder, skill-enhancer, quality-checker, and skill-packager via the skill-architect agent.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/star-prompt/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/star-prompt/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "star-prompt",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Tasteful prompt to encourage users to star the repository after successful command completion",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/testing-quality/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/testing-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "testing-quality",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Testing enforcement, quality metrics, and automation skills",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/twelve-factor/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/twelve-factor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "twelve-factor",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Design-time and audit-time workflows for Twelve-Factor and modern 12+ Factor cloud-native application practices.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/uat-mcp/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/uat-mcp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uat-mcp",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Agent-executable acceptance testing via MCP connections — generate, execute, and report on UAT plans that validate MCP tool surfaces.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/utils/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/utils/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "utils",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Core AIWG utilities for context regeneration and workspace management.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/utils/skills/aiwg-guide/SKILL.md
+++ b/agentic/code/plugins/utils/skills/aiwg-guide/SKILL.md
@@ -2,7 +2,7 @@
 namespace: aiwg
 name: aiwg-guide
 description: Contextual AIWG help — explains current version features, answers how-to questions, routes live queries to the steward
-platforms: [claude-code, codex, opencode, warp, cursor, windsurf, copilot, factory, openclaw, hermes]
+platforms: [all]
 
 ---
 

--- a/agentic/code/plugins/utils/skills/doc-consolidate/SKILL.md
+++ b/agentic/code/plugins/utils/skills/doc-consolidate/SKILL.md
@@ -7,7 +7,7 @@ commandHint:
   allowedTools: Read, Write, Bash, Glob, Grep
   category: utilities
   orchestration: true
-platforms: [claude-code]
+platforms: [all]
 
 ---
 

--- a/agentic/code/plugins/validation-complete/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/validation-complete/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "validation-complete",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Validation Complete for AIWG",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/verbalized-sampling/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/verbalized-sampling/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "verbalized-sampling",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Training-free prompting technique that improves output diversity by 1.6-2.1x through verbalized probability distributions, addressing RLHF mode collapse",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/voice/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/voice/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voice",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Voice profile system for consistent, authentic writing.",
   "author": {
     "name": "AIWG Contributors",

--- a/agentic/code/plugins/writing/.claude-plugin/plugin.json
+++ b/agentic/code/plugins/writing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "writing",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Writing quality validation and AI pattern detection.",
   "author": {
     "name": "AIWG Contributors",

--- a/apps/cockpit/package-lock.json
+++ b/apps/cockpit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiwg/cockpit",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiwg/cockpit",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "license": "MIT",
       "workspaces": [
         "mock-executor",

--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiwg/cockpit",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "AIWG Cockpit — UX-first control plane over AIWG + multi-stack agentic sessions. Opt-in, separately published; NOT shipped in the base aiwg npm package (guarded by test/smoke/cockpit-base-footprint.test.js).",
   "type": "module",
   "license": "MIT",

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -698,6 +698,9 @@ reload are shown with `--verbose`.
 
 | Platform       | `--provider` ID | Artifact dirs                                                                                                         | Behaviors |
 | -------------- | --------------- | --------------------------------------------------------------------------------------------------------------------- | --------- |
+| Google Antigravity CLI (experimental) | `antigravity` (`agy`) | `.agents/agents/`, `.agents/skills/`, project `AGENTS.md`; global skills unsupported | — |
+| Oh My Pi (experimental) | `omp` (`oh-my-pi`) | `.omp/agents/`, `.omp/prompts/`, `.omp/rules/`, `.agents/skills/`, `.omp/AGENTS.md` | Explicit extension bridge |
+| Pi Coding Agent (experimental) | `pi` | `.agents/skills/`, `.pi/prompts/`, `.pi/.aiwg/skills/`, project `AGENTS.md` | — |
 | Claude Code    | `claude`        | `.claude/agents/`, `.claude/commands/`, `.claude/skills/`, `.claude/rules/`                                           | —         |
 | GitHub Copilot | `copilot`       | `.github/agents/`, `.github/copilot-rules/`, `.github/skills/`                                                        | —         |
 | Factory AI     | `factory`       | `.factory/droids/`, `.factory/commands/`, `.factory/skills/`, `.factory/rules/`                                       | —         |
@@ -3946,7 +3949,12 @@ aiwg discover "<phrase>" [options]
 - `--format text` — Emit readable text output (default).
 - `--pretty` — Pretty-print JSON output with indentation (default for compatibility).
 - `--compact` — Emit single-line JSON output for scripts.
-- `--graph <name>` — Override the default graph. Defaults to `framework` (the AIWG capability graph), which is rebuilt automatically after every `aiwg use`.
+- `--graph <name>` — Select one graph explicitly. Default local capability
+  discovery combines `project`, `user` (when project policy permits), and
+  `framework`. Default discovery and show use an existing local project index
+  when its Fortemi cache is unavailable or stale, with one actionable warning
+  on stderr. Normal lookup needs no graph or backend override; explicit graph
+  selection retains cache diagnostics.
 - `--backend <fortemi-core|local>` — Query backend. Default is
   `fortemi-core`; `local` selects the legacy local fallback. The Fortemi Core
   backend reads the static cache created by `aiwg index sync`. For the

--- a/docs/customization/project-local-lifecycle.md
+++ b/docs/customization/project-local-lifecycle.md
@@ -142,6 +142,13 @@ Per-bundle deploy:
 
 `--dry-run` and `--no-project-local` are supported.
 
+Successful project-local reconciliation rebuilds the project capability index
+and synchronizes its Fortemi cache, including pre-existing bundles during
+`use`, `refresh`, and upgrades. Default `aiwg discover` and `aiwg show` also
+fall back to an existing local project index with a bounded warning if the
+cache is absent or stale. Normal capability lookup needs no graph or backend
+flags. Dry runs do not rebuild or synchronize caches.
+
 Each project-local deploy resolves a managed quickref from discovered bundles
 (or a legacy `.aiwg/quickref.json`) and refreshes that provider's project
 quickref. The generated skill stays short: it states local precedence and

--- a/docs/customization/project-local-troubleshooting.md
+++ b/docs/customization/project-local-troubleshooting.md
@@ -3,6 +3,29 @@
 Common failures and how to fix them. Pair with `aiwg doctor --project-local`
 which surfaces most of these automatically.
 
+## Project skill missing from discovery
+
+Use the normal capability commands for existing project-local bundles:
+
+```bash
+aiwg discover "advance roadmap"
+aiwg show skill fortemi-roadmap-skill
+```
+
+Default discovery and show include the local project index when its Fortemi
+cache is absent, stale, or unreadable. A single warning on stderr explains
+the fallback; JSON output and fetched skill bodies remain unchanged. Agents
+do not need graph or backend flags for this flow.
+
+Successful project-local deployment through `use`, `refresh`, or upgrade
+reconciliation rebuilds the project index and synchronizes its cache. To
+repair a cache without redeploying, operators can run `aiwg index sync`.
+If the cache is unavailable and the local index is missing or empty, the
+warning instead directs operators to `aiwg index build --graph project`.
+
+Explicit graph/backend selections retain their diagnostic behavior for
+operators investigating the storage layer.
+
 ## Manifest validation errors
 
 ### "Bundle in .aiwg/extensions/ must declare type: \"extension\""

--- a/docs/extensions/graph-backends.md
+++ b/docs/extensions/graph-backends.md
@@ -210,11 +210,11 @@ source digests, database/WAL size, CPU/RSS, throughput, latency percentiles,
 and event-loop delay.
 
 <!-- aiwg-storage-benchmark-claim:sqlite-local-reference-v1:start -->
-A 2026-08-28 reference-host qualification on linux x64, Node 24.12.0, better-sqlite3 12.8.0, and SQLite 3.51.3 produced:
+A 2026-09-05 reference-host qualification on linux x64, Node 24.12.0, better-sqlite3 12.8.0, and SQLite 3.51.3 produced:
 
 | Nodes / edges | Write throughput | Query + traversal pairs | Write latency p50/p95/p99 | Query latency p50/p95/p99 | Event-loop delay p95 | DB / peak WAL bytes |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 10,000 / 9,999 | 4,011 ops/s | 506 pairs/s | 254.77 / 378.22 / 378.22 ms | 1.2 / 1.97 / 2.74 ms | 378.27 ms | 2,379,776 / 4,157,112 |
+| 10,000 / 9,999 | 5,081 ops/s | 538 pairs/s | 202.21 / 225.59 / 225.59 ms | 1.09 / 2 / 2.7 ms | 225.93 ms | 2,379,776 / 4,157,112 |
 
 Evidence: [sqlite-local-reference-v1](../storage/evidence/sqlite-local-reference-v1.json). The release gate rejects this claim when its correctness digest, source digest, freshness window, or rendered values no longer match.
 <!-- aiwg-storage-benchmark-claim:sqlite-local-reference-v1:end -->

--- a/docs/releases/v2026.9.3-announcement.md
+++ b/docs/releases/v2026.9.3-announcement.md
@@ -1,0 +1,81 @@
+# AIWG 2026.9.3 - Broader provider support, reliable project discovery
+
+**Release date:** 2026-09-05
+
+**Channel:** stable
+
+AIWG 2026.9.3 adds experimental Oh My Pi and Google Antigravity integrations,
+promotes Hermes to stable, and fixes discovery of existing project-local
+skills when a Fortemi Core project cache is unavailable.
+
+## Find the workflows already in your project
+
+An existing skill under `.aiwg/extensions/`, `.aiwg/addons/`, or another
+configured project-local bundle root now remains available to `aiwg discover`
+when the project cache is missing, stale, or corrupt. Discovery falls back to the local project index with a bounded warning;
+deployment, refresh, and upgrade also synchronize the project index after
+reconciling local bundles.
+
+```bash
+aiwg discover "your project workflow"
+aiwg show skill your-project-skill
+```
+
+Portable workflows such as `aiwg-guide`, `doc-consolidate`, and the five
+semantic-memory skills now declare `platforms: [all]`. Their canonical and
+plugin copies no longer exclude newer providers through outdated allowlists.
+
+## Use OMP and Antigravity with explicit support boundaries
+
+```bash
+aiwg use sdlc --provider omp
+aiwg use sdlc --provider antigravity
+```
+
+OMP has its own resource paths, profiles, MCP integration, model discovery,
+JSON/RPC execution, and native session imports. Its reviewed baseline is
+18.1.10, with native conformance checks on Linux x64; other operating systems
+and newer releases remain unverified.
+
+Antigravity supports project skills and agent projections, collision-safe MCP
+configuration, and bounded headless execution. Offline conformance is pinned
+to CLI 1.1.26. Authenticated model execution has not been qualified, global
+skill deployment remains unsupported, and agent projection is degraded.
+
+Both integrations remain experimental. Hermes is now classified as stable.
+The published inventory covers 14 named providers plus a generic fallback.
+
+## Inspect Fortemi compatibility and recover from SQLite startup contention
+
+Fortemi live storage qualification produces sanitized receipts recording the
+tested revision, server contract, complete operation inventory, mutation status,
+and resource bounds. Dataset workflows gain a live contract preflight and UAT
+plan. Fortemi MCP reads now accept nested content responses, and search can
+retrieve missing note metadata before filtering results to the subsystem.
+
+Fortemi Server remains alpha and pre-certification. Live checks default to
+read-only and gate writes separately. These checks do not establish general
+persistence, recovery, migration, or load guarantees. The Fortemi Core cache
+used for capability discovery is separate and needs no live Server endpoint.
+
+SQLite graph initialization now retries temporary journal-mode and schema
+locks within its configured busy timeout and closes failed connections. The
+fix includes a deterministic contention regression and regenerated benchmark
+evidence from the changed source.
+
+## Upgrade and references
+
+```bash
+npm install -g aiwg@2026.9.3
+aiwg refresh --skip-update
+```
+
+This release also adopts Contributor Covenant 2.0 community standards.
+The package versions are `aiwg@2026.9.3`, `@aiwg/cli@2026.9.3`, and
+`@aiwg/cockpit@2026.9.3`.
+
+- [OMP provider guide](https://github.com/jmagly/aiwg/blob/v2026.9.3/docs/providers/omp.md)
+- [Antigravity provider guide](https://github.com/jmagly/aiwg/blob/v2026.9.3/docs/providers/antigravity.md)
+- [Fortemi storage qualification](https://github.com/jmagly/aiwg/blob/v2026.9.3/docs/storage/backends/fortemi.md#live-qualification)
+- [Project capability discovery](https://github.com/jmagly/aiwg/blob/v2026.9.3/docs/fortemi-core-prebuilt-indices.md)
+- [Changelog](https://github.com/jmagly/aiwg/blob/v2026.9.3/CHANGELOG.md)

--- a/docs/skills/agent-skills.md
+++ b/docs/skills/agent-skills.md
@@ -13,6 +13,16 @@ policy.
 
 ## Complete workflow
 
+Portable AIWG source skills use `platforms: [all]`, so explicit copies also
+work with newly added providers. Enumerate providers only when a skill
+requires a specific native tool, and document that dependency in its body.
+The shipped help, document consolidation, and semantic-memory workflows use
+generic file operations and CLI commands and need no provider allowlist.
+
+Platform restrictions control copying into provider directories. Indexed
+`aiwg discover` and `aiwg show` still expose the source independently of
+whether the current provider can load or execute a native skill.
+
 The repository fixture at
 `test/fixtures/agent-skills/lifecycle/portable-complete/` is a complete example.
 The commands below assume its directory has been copied to

--- a/docs/storage/backends/fortemi.md
+++ b/docs/storage/backends/fortemi.md
@@ -84,22 +84,28 @@ name, never its value.
 
 ## How it works
 
-The adapter routes the storage interface to Fortemi MCP tools:
+The adapter selects a tool profile from the discovered MCP input schemas,
+not the server version. `legacy-note-id` supports the older `note_id` contract;
+`source-addressed-v1` requires UUID `get_note` identities and source-addressed
+`upsert_external_notes` fields. Unsupported tool contracts fail initialization.
 
-| AIWG op | Fortemi tool                                  |
-| ------- | --------------------------------------------- |
-| `read`  | `get_note`                                    |
-| `write` (new) | `capture_knowledge`                     |
-| `write` (existing) | `update_note` (versions are first-class) |
-| `list`  | `list_notes` (filtered by `id_prefix`)        |
-| `delete`| `update_note { archived: true }` (Fortemi is immutable) |
-| `query` | `search`                                      |
+| AIWG op | `legacy-note-id` | `source-addressed-v1` |
+| --- | --- | --- |
+| `read` | `get_note { note_id }` | `get_note { id }` with a stable UUID |
+| `write` | `capture_knowledge` for new notes; `update_note` for existing notes | `upsert_external_notes` with `policy: replace` |
+| `list` | `list_notes` with `id_prefix` and optional scheme | `list_notes { limit: 500, offset: 0 }`, then local metadata and prefix filtering |
+| `delete` | `update_note { note_id, archived: true }` | `update_note { id, archived: true }` |
+| `query` | `search` with subsystem `id_prefix` and optional scheme | `search { action: text, query, limit: 50 }`, then metadata filtering |
 
-### Note-id namespacing
+### Entry identity
 
-Each entry stored in Fortemi has `note_id = subsystem + ':' + path`. The subsystem prefix prevents collisions across `kb`/`memory`/`research`/etc. when they share a single Fortemi instance.
-
-Example: `aiwg memory put research-complete/index.md` → Fortemi note_id `memory:research-complete/index.md`.
+The legacy profile uses `note_id = subsystem + ':' + path`, for example
+`memory:research-complete/index.md`. The source-addressed profile derives a
+stable opaque UUID from the subsystem and path. It writes under
+`source_namespace: aiwg.storage.<subsystem>`, with the path as `external_id`,
+the UUID as `caller_stable_id`, and metadata containing `subsystem` and
+`aiwg_storage_path`. An optional scheme is retained in metadata. Returned
+storage paths remain the original relative paths in both profiles.
 
 ### Delete semantics
 
@@ -109,20 +115,29 @@ Fortemi's design is immutable — no destructive delete. The adapter's `delete()
 
 | Operation | Notes                                                          |
 | --------- | -------------------------------------------------------------- |
-| `read`    | Returns `null` for `not_found`; prefers `revised_content`      |
-| `write`   | Calls `capture_knowledge` for new IDs, `update_note` for existing |
-| `list`    | Filters by subsystem prefix; strips prefix from returned paths |
+| `read`    | Returns `null` for `not_found`; reads revised/original nested content and legacy content fields |
+| `write`   | Uses the negotiated profile: legacy create/update or source-addressed upsert |
+| `list`    | Returns subsystem-relative paths; source-addressed listing is bounded to the first 500 server notes |
 | `delete`  | Archives via `update_note`; no-op for missing                  |
 | `query`   | Implemented (Fortemi has native semantic search)               |
 
 ## Caveats
 
-- **Alpha stability.** Parameter shapes are based on the planning doc, not a live API. File issues if you see schema mismatches.
+- **Alpha stability.** Tool profiles are negotiated from MCP schemas; this does not establish general server persistence or recovery certification. Use the live qualification gate to check endpoint compatibility.
 - **Async model.** Fortemi's NLP pipeline runs server-side; `write` returns when the tool call is accepted, not when the artifact is queryable.
 - **Transport security.** Stdio supports local workstation installs. Streamable
   HTTP and legacy SSE support remote services; non-loopback endpoints require
   HTTPS and missing credential references fail closed.
-- **No `update`-on-conflict semantics.** Two concurrent `write`s to the same `note_id` may race at the Fortemi side. Behavior is governed by Fortemi's versioning model, not by the adapter.
+- **Bounded listing and search.** Source-addressed listing requests only the first
+  500 server notes, then filters locally; it does not paginate and may omit
+  subsystem entries beyond that page. Source-addressed search requests at most
+  50 text hits. The adapter processes at most 50 hits in either profile; UUID
+  hits lacking path metadata may each require one `get_note` hydration before
+  subsystem filtering. These bounds can produce fewer matches than the server
+  contains.
+- **Concurrent writes.** The source-addressed profile requests replacement
+  upserts, while the legacy profile uses create/update calls. The adapter
+  provides no cross-client locking or compare-and-swap guarantee.
 
 ## Live qualification
 

--- a/docs/storage/evidence/sqlite-local-reference-v1.json
+++ b/docs/storage/evidence/sqlite-local-reference-v1.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": "aiwg.sqlite-graph-benchmark/v1",
   "evidenceId": "sqlite-local-reference-v1",
-  "observedAt": "2026-08-28T15:14:02.131Z",
-  "validUntil": "2026-11-26T15:14:02.131Z",
+  "observedAt": "2026-09-05T04:44:32.803Z",
+  "validUntil": "2026-12-04T04:44:32.803Z",
   "subject": {
     "branch": "main",
-    "commit": "ef9f70675d064790b20033a001ed064aab4e4ed3",
+    "commit": "8dae7094e7565bb941d7f8866170702281008544",
     "sourceFiles": [
       "src/artifacts/backends/sqlite-backend.ts",
       "tools/benchmarks/sqlite-graph.ts"
     ],
-    "sourceDigest": "619fd7680ce27a73a525e2f885c46c67342af9d711243f451f8f5c6e506c029d"
+    "sourceDigest": "501a5c661e3653bbf2b8c34c71cbe0812c860acd72ee282481722f72a92b4e8c"
   },
   "runtime": {
     "node": "v24.12.0",
@@ -40,24 +40,24 @@
     "observedDigest": "3961ba6906c85863dd1dd57f0ea4c5fab5b6b1038ab3b11cad174078e080ccce"
   },
   "measured": {
-    "writeMs": 4985.96,
-    "writesPerSecond": 4011.06,
+    "writeMs": 3935.91,
+    "writesPerSecond": 5081.16,
     "writeLatencyMs": {
-      "p50": 254.77,
-      "p95": 378.22,
-      "p99": 378.22
+      "p50": 202.21,
+      "p95": 225.59,
+      "p99": 225.59
     },
-    "queryMs": 1977.69,
-    "queryPairsPerSecond": 505.64,
+    "queryMs": 1858.98,
+    "queryPairsPerSecond": 537.93,
     "queryLatencyMs": {
-      "p50": 1.2,
-      "p95": 1.97,
-      "p99": 2.74
+      "p50": 1.09,
+      "p95": 2,
+      "p99": 2.7
     },
-    "eventLoopDelayMsP50": 262.8,
-    "eventLoopDelayMsP95": 378.27,
-    "eventLoopDelayMsP99": 378.27,
-    "eventLoopDelayMsMax": 378.27,
+    "eventLoopDelayMsP50": 203.92,
+    "eventLoopDelayMsP95": 225.93,
+    "eventLoopDelayMsP99": 225.93,
+    "eventLoopDelayMsMax": 225.93,
     "databaseBytes": 2379776,
     "walBytes": 4157112,
     "writeAmplification": 5.63,
@@ -69,9 +69,9 @@
     "walBusy": 0,
     "walFrames": 609,
     "checkpointedFrames": 0,
-    "cpuUserMicros": 3458098,
-    "cpuSystemMicros": 588254,
-    "rssBytes": 378109952
+    "cpuUserMicros": 3991169,
+    "cpuSystemMicros": 708481,
+    "rssBytes": 422797312
   },
   "interpretation": "Reference-host observation only; not a universal support limit."
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiwg",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiwg",
-      "version": "2026.9.2",
+      "version": "2026.9.3",
       "license": "MIT",
       "dependencies": {
         "@fortemi/core": "2026.7.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiwg",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Deployment tool and support utility for AI context. Copies agents, skills, commands, rules, and behaviors into the paths each AI provider reads, so one source of truth works across 14 named provider integrations plus a generic fallback adapter. Optional utilities support persistent artifact memory, background orchestration, autonomous loops, and artifact indexing.",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiwg/cli",
-  "version": "2026.9.2",
+  "version": "2026.9.3",
   "description": "Lightweight AIWG CLI for signed, versioned web-backed resources.",
   "type": "module",
   "license": "MIT",

--- a/src/artifacts/backends/sqlite-backend.ts
+++ b/src/artifacts/backends/sqlite-backend.ts
@@ -66,22 +66,30 @@ export class SqliteGraphBackend implements GraphBackend {
       );
     }
 
-    this.assertSafeSqliteVersion();
-    const requestedJournal = dbPath === ':memory:' ? 'memory' : 'wal';
-    const actualJournal = String(this.db.pragma(`journal_mode = ${requestedJournal}`, { simple: true })).toLowerCase();
-    if (actualJournal !== requestedJournal) {
+    try {
+      // Changing journal mode may return SQLITE_BUSY without invoking SQLite's
+      // busy handler during a lock upgrade. Retry initialization as a whole:
+      // pragmas are idempotent and failed schema transactions roll back.
+      this.withBusyContext('initializing the graph database', () => {
+        this.assertSafeSqliteVersion();
+        const requestedJournal = dbPath === ':memory:' ? 'memory' : 'wal';
+        const actualJournal = String(this.db.pragma(`journal_mode = ${requestedJournal}`, { simple: true })).toLowerCase();
+        if (actualJournal !== requestedJournal) {
+          throw new Error(`sqlite backend requested journal_mode=${requestedJournal} but received ${actualJournal}`);
+        }
+        this.db.pragma(`synchronous = ${options.synchronous ?? 'NORMAL'}`);
+        this.db.pragma('wal_autocheckpoint = 1000');
+        this.migrateSchema();
+      });
+    } catch (error) {
       this.db.close();
-      throw new Error(`sqlite backend requested journal_mode=${requestedJournal} but received ${actualJournal}`);
+      throw error;
     }
-    this.db.pragma(`synchronous = ${options.synchronous ?? 'NORMAL'}`);
-    this.db.pragma('wal_autocheckpoint = 1000');
-    this.migrateSchema();
   }
 
   private assertSafeSqliteVersion(): void {
     const version = String(this.db.prepare('SELECT sqlite_version() AS version').get().version);
     if (!isWalResetSafeVersion(version)) {
-      this.db.close();
       throw new Error(
         `sqlite backend requires a WAL-reset-safe SQLite build (3.44.6, 3.50.7, or >=3.51.3); found ${version}`,
       );
@@ -91,7 +99,6 @@ export class SqliteGraphBackend implements GraphBackend {
   private migrateSchema(): void {
     const current = Number(this.db.pragma('user_version', { simple: true }));
     if (current > SCHEMA_VERSION) {
-      this.db.close();
       throw new Error(`sqlite graph schema ${current} is newer than supported schema ${SCHEMA_VERSION}`);
     }
     if (current === SCHEMA_VERSION) return;

--- a/src/artifacts/query-engine.ts
+++ b/src/artifacts/query-engine.ts
@@ -138,6 +138,25 @@ function withIndexProvenance(entry: MetadataEntry, graph: GraphType): Provenance
   return { ...entry, indexGraph: graph, indexScope: graphScope(graph) };
 }
 
+/** Keep existing project capabilities visible while their derived cache is unavailable. */
+function projectCapabilityFallback(cwd: string): MetadataEntry[] | null {
+  const index = loadGraphIndexFile<ArtifactIndex>(cwd, 'metadata.json', 'project');
+  if (index) {
+    const entries = Object.values(index.entries).map((entry) => withIndexProvenance(entry, 'project'));
+    if (entries.length > 0) {
+      // One diagnostic per command, on stderr so JSON and skill bodies stay parseable.
+      console.error('Warning: project capability cache is unavailable or stale; using the local project index. Run `aiwg index sync` to repair the cache.');
+      return entries;
+    }
+  }
+  if (['extensions', 'addons', 'frameworks', 'plugins', 'skills'].some(
+    (dir) => fs.existsSync(projectAiwgPath(cwd, dir)),
+  )) {
+    console.error('Warning: project capabilities could not be loaded: the cache is unavailable and the local project index is missing or empty. Run `aiwg index build --graph project` to repair discovery.');
+  }
+  return index ? [] : null;
+}
+
 function discoveryIdForEntry(entry: MetadataEntry): string {
   return stableRecordId(recordTypeForEntry(entry, 'v2'), entry.path);
 }
@@ -1067,6 +1086,13 @@ export async function discoverCapability(
     let unavailableReason: string | undefined;
     for (const graph of graphs) {
       const loaded = loadFortemiCoreMetadataEntries(cwd, graph, verifiedSourcePaths);
+      if (loaded.reason && graph === 'project' && !params.graph) {
+        const fallback = projectCapabilityFallback(cwd);
+        if (fallback) {
+          entries.push(...fallback);
+          continue;
+        }
+      }
       if (loaded.reason) unavailableReason ??= loaded.reason;
       entries.push(...loaded.entries.map((entry) => withIndexProvenance(entry, graph)));
       const discovered = await queryFortemiCoreAiwgDiscovery(cwd, {
@@ -1570,6 +1596,13 @@ async function loadShowEntries(
     let unavailableReason: string | undefined;
     for (const graph of graphs) {
       const loaded = loadFortemiCoreMetadataEntries(cwd, graph);
+      if (loaded.reason && graph === 'project' && !params.graph) {
+        const fallback = projectCapabilityFallback(cwd);
+        if (fallback) {
+          entries.push(...fallback);
+          continue;
+        }
+      }
       if (loaded.reason) unavailableReason ??= loaded.reason;
       entries.push(...loaded.entries.map((entry) => withIndexProvenance(entry, graph)));
     }

--- a/src/cli/handlers/use.ts
+++ b/src/cli/handlers/use.ts
@@ -1590,6 +1590,18 @@ async function deployProjectLocalBundles(opts: {
     }
   }
 
+  // Automatic reconciliation (also used by refresh/upgrade) must restore the
+  // project search cache for existing bundles, just as a named local install
+  // does. Named installs refresh once after all selected providers finish.
+  if (deployed > 0 && !dryRun && !onlyBundleId) {
+    try {
+      await rebuildExternalBundleIndex(projectDir, 'project', verbose);
+    } catch (error) {
+      failed++;
+      ui.warn(`Project-local index refresh failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
   // Refresh the project kernel quickref from either legacy operator input or
   // managed project-local discovery whenever bundles deploy.
   const { hasProjectQuickref, deployProjectQuickref } = await import('../../extensions/project-quickref.js');

--- a/test/integration/artifacts/sqlite-concurrency.test.ts
+++ b/test/integration/artifacts/sqlite-concurrency.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
+import { once } from 'node:events';
 import { afterEach, describe, expect, it } from 'vitest';
 import { SqliteGraphBackend } from '../../../src/artifacts/backends/sqlite-backend.js';
 
@@ -19,6 +20,33 @@ afterEach(async () => {
 });
 
 describe('SQLite same-host concurrency and crash recovery (#2189)', () => {
+  it('waits for a rollback-journal writer before initializing WAL and the graph schema', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'aiwg-sqlite-init-'));
+    roots.push(root);
+    const dbPath = join(root, 'graph.db');
+    const locker = execFile(process.execPath, ['--input-type=module', '--eval', `
+      import Database from 'better-sqlite3';
+      const db = new Database(process.argv[1]);
+      db.exec('CREATE TABLE seed (id TEXT); BEGIN IMMEDIATE');
+      process.stdout.write('locked\\n');
+      setTimeout(() => { db.exec('COMMIT'); db.close(); }, 250);
+    `, dbPath]);
+    const exited = once(locker, 'exit');
+    await once(locker.stdout!, 'data');
+    try {
+      const graph = new SqliteGraphBackend(dbPath, { busyTimeoutMs: 2_000 });
+      try {
+        graph.addNode('initialized');
+        expect(graph.hasNode('initialized')).toBe(true);
+        expect(graph.walMetrics().busy).toBe(0);
+      } finally {
+        graph.close();
+      }
+    } finally {
+      await exited;
+    }
+  }, 10_000);
+
   it('serializes multiple processes, deduplicates same-key races, and reopens committed WAL writes', async () => {
     const root = await mkdtemp(join(tmpdir(), 'aiwg-sqlite-concurrency-'));
     roots.push(root);

--- a/test/integration/portable-skill-platforms.test.ts
+++ b/test/integration/portable-skill-platforms.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { deploySkillDir, skillMatchesProvider } from '../../tools/agents/providers/base.mjs';
+import { buildIndex } from '../../src/artifacts/index-builder.js';
+import { syncFortemiCoreIndex } from '../../src/artifacts/fortemi-core-sync.js';
+import { main as indexCliMain } from '../../src/artifacts/cli.js';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const providers = ['openhuman', 'pi', 'omp', 'antigravity', 'future-provider'];
+const portable = [
+  ['aiwg-utils', 'aiwg-guide'],
+  ['aiwg-utils', 'doc-consolidate'],
+  ...['memory-log-render', 'memory-log-append', 'memory-query-capture', 'memory-lint', 'memory-ingest']
+    .map(name => ['semantic-memory', name]),
+];
+
+describe('portable skill copies and independent indexed retrieval (#2282)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'aiwg-portable-skills-'));
+    vi.stubEnv('HOME', path.join(tmp, 'home'));
+    vi.stubEnv('XDG_DATA_HOME', path.join(tmp, 'data'));
+    vi.stubEnv('AIWG_ROOT', tmp);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it.each(providers)('explicitly copies portable skills for %s', provider => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    for (const [bundle, name] of portable) {
+      for (const container of ['addons', 'plugins']) {
+        const sourceBundle = container === 'plugins' && bundle === 'aiwg-utils' ? 'utils' : bundle;
+        const source = path.join(root, 'agentic/code', container, sourceBundle, 'skills', name);
+        const content = fs.readFileSync(path.join(source, 'SKILL.md'), 'utf8');
+        expect(skillMatchesProvider(content, provider), `${container}/${name}`).toBe(true);
+        const dest = path.join(tmp, container);
+        deploySkillDir(source, dest, { provider });
+        const copied = fs.readFileSync(path.join(dest, name, 'SKILL.md'), 'utf8');
+        expect(copied).toContain(`platforms: [${provider}]`);
+        expect(copied.replace(/^---\n[\s\S]*?\n---/, '')).toBe(content.replace(/^---\n[\s\S]*?\n---/, ''));
+      }
+    }
+  });
+
+  it.each(providers)('copies framework and packaged doc-consolidate variants for %s', provider => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    for (const bundle of ['frameworks/sdlc-complete', 'plugins/sdlc', 'plugins/codex-sdlc']) {
+      const source = path.join(root, 'agentic/code', bundle, 'skills/doc-consolidate');
+      const dest = path.join(tmp, bundle);
+      deploySkillDir(source, dest, { provider });
+      expect(fs.readFileSync(path.join(dest, 'doc-consolidate/SKILL.md'), 'utf8'))
+        .toContain(`platforms: [${provider}]`);
+    }
+  });
+
+  it('retrieves source skills independently of provider copy restrictions', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const source = path.join(tmp, '.aiwg/extensions/help/skills/aiwg-guide');
+    fs.mkdirSync(source, { recursive: true });
+    const content = fs.readFileSync(path.join(root, 'agentic/code/addons/aiwg-utils/skills/aiwg-guide/SKILL.md'), 'utf8');
+    fs.writeFileSync(path.join(source, 'SKILL.md'), content);
+    const restricted = path.join(tmp, '.aiwg/extensions/help/skills/native-only');
+    fs.mkdirSync(restricted, { recursive: true });
+    fs.writeFileSync(path.join(restricted, 'SKILL.md'), [
+      '---', 'name: native-only', 'description: Native inspector fixture',
+      'platforms: [claude-code]', '---', '# Native Inspector', '',
+      'Requires the native fixture tool.',
+    ].join('\n'));
+    deploySkillDir(restricted, path.join(tmp, 'copies'), { provider: 'future-provider' });
+    expect(fs.existsSync(path.join(tmp, 'copies/native-only'))).toBe(false);
+    await buildIndex(tmp, { graph: 'project', quiet: true });
+    syncFortemiCoreIndex(tmp, { graph: 'project' });
+    vi.spyOn(process, 'cwd').mockReturnValue(tmp);
+    for (const name of ['aiwg-guide', 'native-only']) {
+      log.mockClear();
+      await indexCliMain(['discover', name, '--json']);
+      const found = JSON.parse(log.mock.calls.map(call => call[0]).join(''));
+      expect(found.results[0].name).toBe(name);
+      log.mockClear();
+      await indexCliMain(['show', 'skill', found.results[0].id, '--json']);
+      const shown = JSON.parse(log.mock.calls.map(call => call[0]).join(''));
+      expect(shown.content).toBe(fs.readFileSync(path.join(path.dirname(source), name, 'SKILL.md'), 'utf8'));
+    }
+  });
+});

--- a/test/integration/project-local-deploy.test.ts
+++ b/test/integration/project-local-deploy.test.ts
@@ -201,6 +201,46 @@ describe('project-local deploy integration (#1046)', () => {
     cleanup(env);
   });
 
+  it.each([
+    ['use', ['use', 'sdlc', '--provider', 'claude', '--quiet']],
+    ['refresh', ['refresh', '--skip-update', '--provider', 'claude', '--quiet']],
+    ['upgrade', ['upgrade', '--skip-check', '--provider', 'claude']],
+  ])('%s synchronizes existing project-local skills without a project cache (#2155)', (_command, args) => {
+    // Model an established workspace whose bundles predate the Fortemi cache.
+    // No scaffold command or named local install has populated its index.
+    writeFileSync(path.join(env.projectDir, '.aiwg', 'aiwg.config'), JSON.stringify({
+      version: '1',
+      providers: ['claude'],
+      installed: { sdlc: {
+        version: '1.0', source: 'bundled', installedAt: '2026-01-01T00:00:00Z',
+        deployedTo: { claude: { agents: 0, commands: 0, skills: 0, rules: 0 } },
+      } },
+    }));
+    mkdirSync(path.join(env.projectDir, '.aiwg', 'frameworks'), { recursive: true });
+    writeFileSync(path.join(env.projectDir, '.aiwg', 'frameworks', 'registry.json'), JSON.stringify({
+      version: '1.0',
+      frameworks: [{ id: 'sdlc-complete', installed: '2026-01-01', version: '1.0' }],
+    }));
+    const cache = path.join(env.projectDir, '.aiwg', '.index', 'fortemi-core', 'project', 'aiwg-fortemi-index-v2.json');
+    expect(existsSync(cache)).toBe(false);
+
+    const result = runAiwg(env, args);
+
+    expect(result.status, result.stdout).toBe(0);
+    expect(existsSync(cache), result.stdout).toBe(true);
+    const exported = JSON.parse(readFileSync(cache, 'utf8'));
+    expect(exported.items).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'demo-skill' }),
+    ]));
+  }, 180_000);
+
+  it('automatic local reconciliation leaves the project cache absent on dry-run (#2155)', () => {
+    writeFileSync(path.join(env.projectDir, '.aiwg', 'aiwg.config'), JSON.stringify({ providers: ['claude'] }));
+    const result = runAiwg(env, ['use', 'sdlc', '--provider', 'claude', '--dry-run', '--quiet']);
+    expect(result.status, result.stdout).toBe(0);
+    expect(existsSync(path.join(env.projectDir, '.aiwg', '.index', 'fortemi-core', 'project'))).toBe(false);
+  }, 180_000);
+
   it('bootstraps a managed quickref preview from bundles with zero dry-run writes', () => {
     writeFileSync(
       path.join(env.projectDir, '.aiwg', 'aiwg.config'),

--- a/test/unit/addons/aiwg-guide.test.ts
+++ b/test/unit/addons/aiwg-guide.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFile, access } from 'fs/promises';
 import { join } from 'path';
 import { constants } from 'fs';
+import { parse as parseYaml } from 'yaml';
 
 const SKILL_PATH = 'agentic/code/addons/aiwg-utils/skills/aiwg-guide';
 const SKILL_FILE = join(SKILL_PATH, 'SKILL.md');
@@ -20,7 +21,8 @@ describe('aiwg-guide skill (#616)', () => {
       expect(content).toMatch(/\n---\n/);
       expect(content).toMatch(/description:/);
       expect(content).toMatch(/platforms:/);
-      expect(content).toContain('claude-code');
+      const frontmatter = parseYaml(content.split('---')[1]);
+      expect(frontmatter.platforms).toEqual(['all']);
     });
 
     it('should follow standard section ordering', async () => {

--- a/test/unit/artifacts/fortemi-core-discover-show.test.ts
+++ b/test/unit/artifacts/fortemi-core-discover-show.test.ts
@@ -156,6 +156,83 @@ describe("Fortemi Core discover/show parity adapter (#1688)", () => {
     return createHash("sha256").update(text).digest("hex");
   }
 
+  it.each(['absent', 'stale', 'corrupt'])(
+    'keeps a pre-existing bundle discoverable and showable with a %s project cache (#2155)',
+    async (cacheState) => {
+      const skillPath = '.aiwg/extensions/fortemi-roadmap/skills/fortemi-roadmap-skill/SKILL.md';
+      fs.mkdirSync(path.dirname(path.join(tmp, skillPath)), { recursive: true });
+      fs.writeFileSync(path.join(tmp, skillPath), [
+        '---', 'name: fortemi-roadmap-skill',
+        'description: Advance the project roadmap',
+        'triggers:', '  - "advance roadmap"', '---',
+        '# Project Roadmap', '', 'Follow the required project roadmap procedure.',
+      ].join('\n'));
+      // An existing workspace has a local index, without going through new-bundle.
+      await buildIndex(tmp, { graph: 'project', quiet: true });
+      if (cacheState !== 'absent') {
+        syncFortemiCoreIndex(tmp, { graph: 'project' });
+        const status = getFortemiCoreSyncStatus(tmp, 'project');
+        if (cacheState === 'corrupt') {
+          fs.writeFileSync(status.exportPath, '{broken');
+        } else {
+          const metadataPath = path.join(getGraphIndexDir(tmp, 'project'), 'metadata.json');
+          const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+          metadata.builtAt = new Date(Date.now() + 60_000).toISOString();
+          fs.writeFileSync(metadataPath, JSON.stringify(metadata));
+        }
+        expect(getFortemiCoreSyncStatus(tmp, 'project').stale).toBe(true);
+      } else {
+        expect(getFortemiCoreSyncStatus(tmp, 'project').optedIn).toBe(false);
+      }
+      // A healthy framework export used to mask the missing project graph.
+      writeProjectGraph(tmp, [entry({
+        path: 'agentic/code/addons/roadmap/skills/packaged-roadmap/SKILL.md',
+        name: 'packaged-roadmap', title: 'Packaged Roadmap',
+      })], undefined, 'framework');
+      syncFortemiCoreIndex(tmp, { graph: 'framework' });
+      consoleSpy.mockClear();
+      consoleErrorSpy.mockClear();
+      const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(tmp);
+      try {
+        await indexCliMain(['discover', 'advance roadmap', '--json']);
+        const found = readConsoleJson();
+        expect(found.results[0].name).toBe('fortemi-roadmap-skill');
+        expect(found.results[0].provenance).toEqual({ graph: 'project', scope: 'project' });
+        expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('using the local project index'));
+        for (const name of ['fortemi-roadmap-skill', found.results[0].id]) {
+          consoleSpy.mockClear();
+          consoleErrorSpy.mockClear();
+          await indexCliMain(['show', 'skill', name, '--json']);
+          expect(readConsoleJson().content).toContain('Follow the required project roadmap procedure.');
+          expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+        }
+      } finally {
+        cwdSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each(['missing', 'empty'])('warns when the project cache is absent and its index is %s', async (state) => {
+    fs.mkdirSync(path.join(tmp, '.aiwg/extensions/existing/skills'), { recursive: true });
+    if (state === 'empty') writeProjectGraph(tmp, []);
+    writeProjectGraph(tmp, [entry({
+      path: 'agentic/code/addons/intake/skills/intake-wizard/SKILL.md',
+    })], undefined, 'framework');
+    syncFortemiCoreIndex(tmp, { graph: 'framework' });
+    consoleSpy.mockClear();
+    consoleErrorSpy.mockClear();
+    await discoverCapability(tmp, { phrase: 'intake', json: true });
+    expect(readConsoleJson().results[0].name).toBe('intake-wizard');
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('aiwg index build --graph project'));
+    consoleSpy.mockClear();
+    consoleErrorSpy.mockClear();
+    await showArtifact(tmp, { name: 'intake-wizard', json: true, backend: 'fortemi-core' });
+    expect(readConsoleJson().content).toContain('Intake Wizard');
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("refreshes the project Fortemi Core cache after index build", async () => {
     const skillDir = path.join(tmp, ".aiwg", "addons", "schema-registry", "skills", "schema-registry");
     fs.mkdirSync(skillDir, { recursive: true });
@@ -901,6 +978,8 @@ describe("Fortemi Core discover/show parity adapter (#1688)", () => {
   });
 
   it("fails explicitly when the Fortemi Core cache is unavailable", async () => {
+    // Explicit operator queries must not silently switch to this valid index.
+    writeProjectGraph(tmp, [entry({})]);
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
@@ -920,6 +999,12 @@ describe("Fortemi Core discover/show parity adapter (#1688)", () => {
         "pass '--backend local' to use the legacy local index",
       );
       expect(exitSpy).toHaveBeenCalledWith(1);
+      consoleSpy.mockClear();
+      await expect(showArtifact(tmp, {
+        name: 'intake-wizard', typeFilter: ['skill'], graph: 'project',
+        json: true, backend: 'fortemi-core',
+      })).rejects.toThrow('process.exit');
+      expect(readConsoleJson().error).toContain('aiwg index sync');
     } finally {
       exitSpy.mockRestore();
     }

--- a/test/unit/artifacts/sqlite-backend.test.ts
+++ b/test/unit/artifacts/sqlite-backend.test.ts
@@ -5,7 +5,7 @@
  * @implements #729
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createRequire } from 'module';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -332,6 +332,29 @@ describe.skipIf(!sqliteAvailable)('SqliteGraphBackend', () => {
         locker.exec('ROLLBACK');
         locker.close();
         contender.close();
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+
+    it('closes a failed initialization and reports bounded journal lock exhaustion', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'aiwg-sqlite-init-busy-'));
+      const dbPath = join(root, 'graph.db');
+      const { requireFeaturePackage } = await import('../../../src/features/runtime.js');
+      const Database = requireFeaturePackage('better-sqlite3') as new (path: string) => {
+        exec(sql: string): void;
+        close(): void;
+      };
+      const locker = new Database(dbPath);
+      locker.exec('CREATE TABLE seed (id TEXT); BEGIN IMMEDIATE');
+      const closeSpy = vi.spyOn(Database.prototype, 'close');
+      try {
+        expect(() => new SqliteGraphBackend(dbPath, { busyTimeoutMs: 20 }))
+          .toThrow(expect.objectContaining({ code: 'AIWG_SQLITE_BUSY' }));
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        closeSpy.mockRestore();
+        locker.exec('ROLLBACK');
+        locker.close();
         await rm(root, { recursive: true, force: true });
       }
     });


### PR DESCRIPTION
Synchronize the public mirror with Gitea main through the signed `v2026.9.3` release commit. This delivers the project-local discovery fallback, portable skill metadata, SQLite initialization contention fix, and release documentation while preserving the existing GitHub merge history.

Validation: all eight Gitea CI checks passed on `2b61d42ba67ae513ef339d1af4285b0105c986fd`. Local release gates passed 10,091 main tests, 107 UAT tests, 39 full-corpus discovery tests, metadata validation, build, and the packaged prebuilt-index check.

Canonical CI: https://git.integrolabs.net/roctinam/aiwg/actions/runs/52977
